### PR TITLE
fix: gitignore and .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -447,7 +447,8 @@ $RECYCLE.BIN/
 ##
 ## Visual Studio Code
 ##
-.vscode/*
+.vscode
+**/.vscode
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
The .gitignore file now ignores .vscode folder and everything that folder contains.